### PR TITLE
Displacement fix

### DIFF
--- a/src/COMSETsystem/CityMap.java
+++ b/src/COMSETsystem/CityMap.java
@@ -98,27 +98,24 @@ public class CityMap {
 	 * @param destination The location to arrive at
 	 * @return the time in seconds it takes to go from source to destination
 	 */
-	public long travelTimeBetween (StaticTravelTimeLocationOnRoad source, StaticTravelTimeLocationOnRoad destination) {
+	public long travelTimeBetween (LocationOnRoad source, LocationOnRoad destination) {
 		long travelTime = -1;
-		if (source.road == destination.road && source.travelTimeFromStartIntersection <= destination.travelTimeFromStartIntersection) { 
+		StaticTravelTimeLocationOnRoad sourceTravelTimeLocation = new StaticTravelTimeLocationOnRoad(source);
+		StaticTravelTimeLocationOnRoad destinationTravelTimeLocation = new StaticTravelTimeLocationOnRoad(destination);
+
+		if (source.road == destination.road && source.getDisplacementOnRoad(destination) >= 0) {
 			// If the two locations are on the same road and source is closer to the start intersection than destination, 
 			// then the travel time is the difference of travelTimeFromStartIntersection between source and destination.
-			travelTime = destination.travelTimeFromStartIntersection - source.travelTimeFromStartIntersection;
+			travelTime = destinationTravelTimeLocation.travelTimeFromStartIntersection - sourceTravelTimeLocation.travelTimeFromStartIntersection;
 		} else {
-			long travelTimeToEndIntersectionOfSource = source.road.travelTime - source.travelTimeFromStartIntersection;
-			long travelTimeFromStartIntersectionOfDestination = destination.travelTimeFromStartIntersection;
+			long travelTimeToEndIntersectionOfSource = sourceTravelTimeLocation.road.travelTime - sourceTravelTimeLocation.travelTimeFromStartIntersection;
+			long travelTimeFromStartIntersectionOfDestination = destinationTravelTimeLocation.travelTimeFromStartIntersection;
 			long travelTimeFromEndIntersectionOfSourceToStartIntersectionOfDestination = travelTimeBetween(source.road.to, destination.road.from);
 			travelTime = travelTimeToEndIntersectionOfSource + travelTimeFromEndIntersectionOfSourceToStartIntersectionOfDestination + travelTimeFromStartIntersectionOfDestination;
 		}
 		return travelTime;
 	}
-
-	public long travelTimeBetween(LocationOnRoad source, LocationOnRoad destination) {
-		StaticTravelTimeLocationOnRoad sourceTravelTimeLocation = new StaticTravelTimeLocationOnRoad(source);
-		StaticTravelTimeLocationOnRoad destinationTravelTimeLocation = new StaticTravelTimeLocationOnRoad(destination);
-		return travelTimeBetween(sourceTravelTimeLocation, destinationTravelTimeLocation);
-	}
-
+	
 	/**
 	 * @return { @code projector }
 	 */

--- a/src/COMSETsystem/Link.java
+++ b/src/COMSETsystem/Link.java
@@ -50,7 +50,7 @@ public class Link implements Comparable<Link> {
 		this.to = to;
 		this.length = length;
 		this.speed = speed;
-		this.travelTime = (int)(Math.ceil(length/speed));
+		this.travelTime = (long)(Math.round(length/speed));
 		this.road = null;
 		minX = Math.min(from.xy.getX(), to.getX());
 		minY = Math.min(from.xy.getY(), to.getY());

--- a/src/COMSETsystem/LocationOnRoad.java
+++ b/src/COMSETsystem/LocationOnRoad.java
@@ -24,7 +24,7 @@ public class LocationOnRoad {
     public double getDisplacementOnRoad(LocationOnRoad destination) {
         assert this.road.id == destination.road.id : "two links must be on the same road";
         double displacement = destination.distanceFromStartIntersection - this.distanceFromStartIntersection;
-        return Math.abs(displacement) < Configuration.minimumDistance ? 0.0 : displacement;
+        return displacement;
     }
 
     public long getStaticTravelTimeOnRoad() {

--- a/src/COMSETsystem/ScoreInfo.java
+++ b/src/COMSETsystem/ScoreInfo.java
@@ -204,11 +204,11 @@ class ScoreInfo {
 
         // TODO: Add configuration to control these checks.
         System.out.println("********** Complated Trips time checks");
-        checkAndPrintIntervalRecords(completedTripTime, 10, 0.02);
+        checkAndPrintIntervalRecords(completedTripTime, 10, 0.06);
         // checkAndPrintIntervalRecords(resourcePickupTimeCheckRecords, Integer.MAX_VALUE, 0.0);
 
         System.out.println("********** Approach time checks");
-        checkAndPrintIntervalRecords(approachTimeCheckRecords, 10, 0.02);
+        checkAndPrintIntervalRecords(approachTimeCheckRecords, 10, 0.06);
         // checkAndPrintIntervalRecords(approachTimeCheckRecords, Integer.MAX_VALUE, 0.0);
     }
 

--- a/test/COMSETsystem/CityMapTest.java
+++ b/test/COMSETsystem/CityMapTest.java
@@ -55,7 +55,9 @@ public class CityMapTest {
         simpleMap.roadFrom1to2.speed = 1; // m/s
 
         // The two locations are so close that rounding error causes the travel time in the
-        // converted StaticLocationOnRoad object to be the same
+        // converted StaticLocationOnRoad object to be the same but because travelTimeBetween
+        // use the double-typed distances to determine which route to take, it will recognize that
+        // the origin is past the destination on the road.
         LocationOnRoad origin = SimpleMap.makeLocationFromRoad(simpleMap.roadFrom1to2, 0.30005);
         LocationOnRoad destination = SimpleMap.makeLocationFromRoad(simpleMap.roadFrom1to2, 0.3);
 
@@ -66,5 +68,5 @@ public class CityMapTest {
         // 3600 + 300 + (1000-Round(300.05)) = 4600
         assertEquals(4600, spyMap.travelTimeBetween(origin, destination));
     }
-
 }
+

--- a/test/COMSETsystem/CityMapTest.java
+++ b/test/COMSETsystem/CityMapTest.java
@@ -56,12 +56,15 @@ public class CityMapTest {
 
         // The two locations are so close that rounding error causes the travel time in the
         // converted StaticLocationOnRoad object to be the same
-        LocationOnRoad origin = SimpleMap.makeLocationFromRoad(simpleMap.roadFrom1to2, 0.3005);
+        LocationOnRoad origin = SimpleMap.makeLocationFromRoad(simpleMap.roadFrom1to2, 0.30005);
         LocationOnRoad destination = SimpleMap.makeLocationFromRoad(simpleMap.roadFrom1to2, 0.3);
 
         // setup mock return value for navigation back from intersection2 to intersection1
         doReturn(3600L).when(spyMap).travelTimeBetween(simpleMap.intersection2, simpleMap.intersection1);
-        assertEquals(0, spyMap.travelTimeBetween(origin, destination));
+
+        // 3600 + time from start of road to destination + time from origin to end of road
+        // 3600 + 300 + (1000-Round(300.05)) = 4600
+        assertEquals(4600, spyMap.travelTimeBetween(origin, destination));
     }
 
 }

--- a/test/COMSETsystem/SimpleMap.java
+++ b/test/COMSETsystem/SimpleMap.java
@@ -44,7 +44,7 @@ public class SimpleMap {
     }
 
     public static LocationOnRoad makeLocationFromRoad(Road road, double fraction) {
-        return new LocationOnRoad(road, (long) (road.length * fraction));
+        return new LocationOnRoad(road, road.length * fraction);
     }
 
 


### PR DESCRIPTION
An alternative fix to the displacement confusion. Leave the calculation of getDisplacementOnRoad as double-precision comparison, and let static travel time calculation NOT round-up when comparing the source and the destination. Specifically, in CityMap::travelTimeBetween, when determining whether the destination is downstream of the source, use distance comparison (double-precision) instead of travel-time comparison (long-precision). Only do round-up after the downstream condition is checked. There will be no chance of confusion with this solution: if the destination is downstream of the source and the displacement is smaller than 53.6448.../2.0/time_resolution, then CityMap::travelTimeBetween will correctly determine that the destination is downstream of the source, will not do the loop, and will calculate the travel time to be 0 after round-up. Since the dynamic travel time uses the same round-up method as the static travel time (both use Math.round), the two will be consistent.  